### PR TITLE
Add scheduled SageMaker Autopilot runner for stock time-series (script + GitHub Actions)

### DIFF
--- a/.github/workflows/autopilot_timeseries.yml
+++ b/.github/workflows/autopilot_timeseries.yml
@@ -1,0 +1,45 @@
+name: Autopilot Time Series Forecast
+
+on:
+  schedule:
+    - cron: "0 21 * * 2" # Tuesday 21:00 UTC == 4 PM EST
+  workflow_dispatch:
+
+jobs:
+  run-autopilot:
+    runs-on: ubuntu-latest
+    env:
+      AWS_REGION: us-east-1
+      TICKERS: ${{ secrets.AUTOPILOT_TICKERS }}
+      AUTOPILOT_ROLE_ARN: ${{ secrets.AUTOPILOT_ROLE_ARN }}
+      AUTOPILOT_S3_BUCKET: ${{ secrets.AUTOPILOT_S3_BUCKET }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run Autopilot time series job
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_SESSION_TOKEN: ${{ secrets.AWS_SESSION_TOKEN }}
+        run: |
+          python scripts/run_autopilot_timeseries.py \
+            --tickers "${TICKERS}" \
+            --start "2020-01-01" \
+            --interval "1d" \
+            --s3-bucket "${AUTOPILOT_S3_BUCKET}" \
+            --s3-prefix "autopilot-stock-forecast" \
+            --role-arn "${AUTOPILOT_ROLE_ARN}" \
+            --frequency "1D" \
+            --forecast-horizon 7 \
+            --skip-if-monday-holiday

--- a/scripts/run_autopilot_timeseries.py
+++ b/scripts/run_autopilot_timeseries.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""Run SageMaker Autopilot time series forecasting using fetched stock data."""
+from __future__ import annotations
+
+import argparse
+import os
+from datetime import datetime, timedelta
+from typing import Optional
+
+import boto3
+import pandas as pd
+import pytz
+from pandas.tseries.holiday import USFederalHolidayCalendar
+
+from fetch_data import colab_download_price_csv, ensure_dir
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run Autopilot time series forecast using stock history.")
+    parser.add_argument("--tickers", required=True, help="Comma-separated tickers, e.g. AAPL,MSFT")
+    parser.add_argument("--start", required=True, help="Start date YYYY-MM-DD")
+    parser.add_argument("--end", help="End date YYYY-MM-DD (defaults to today)")
+    parser.add_argument("--interval", default="1d", choices=["1d", "1h"], help="Data interval")
+    parser.add_argument("--s3-bucket", required=True, help="S3 bucket for Autopilot input/output")
+    parser.add_argument("--s3-prefix", default="autopilot-stock-forecast", help="S3 prefix for data")
+    parser.add_argument("--role-arn", required=True, help="IAM role ARN for SageMaker Autopilot job")
+    parser.add_argument("--region", default=os.environ.get("AWS_REGION", "us-east-1"), help="AWS region")
+    parser.add_argument("--forecast-horizon", type=int, default=7, help="Forecast horizon in days")
+    parser.add_argument("--frequency", default="1D", help="Forecast frequency (e.g. 1D, 1H)")
+    parser.add_argument("--max-runtime-seconds", type=int, default=40 * 60, help="Max AutoML runtime")
+    parser.add_argument("--job-name-prefix", default="automl-ts", help="AutoML job name prefix")
+    parser.add_argument(
+        "--skip-if-monday-holiday",
+        action="store_true",
+        help="Skip the run if the previous Monday is a US federal holiday.",
+    )
+    parser.add_argument("--workdir", default="data/autopilot", help="Local working directory")
+    return parser.parse_args()
+
+
+def was_monday_holiday(reference_time: datetime) -> bool:
+    monday = (reference_time - timedelta(days=reference_time.weekday())).date()
+    holidays = USFederalHolidayCalendar().holidays(start=monday, end=monday)
+    return not holidays.empty
+
+
+def build_training_dataframe(csv_paths: list[str]) -> pd.DataFrame:
+    frames = []
+    for path in csv_paths:
+        frame = pd.read_csv(path)
+        frame = frame.rename(columns={"Item_Id": "item_id", "Date": "ts", "Price": "target"})
+        frames.append(frame)
+    combined = pd.concat(frames, ignore_index=True)
+    combined["ts"] = pd.to_datetime(combined["ts"])
+    combined = combined.sort_values(["item_id", "ts"], ascending=True)
+    return combined
+
+
+def upload_to_s3(local_path: str, bucket: str, key: str, region: str) -> str:
+    s3 = boto3.client("s3", region_name=region)
+    s3.upload_file(local_path, bucket, key)
+    return f"s3://{bucket}/{key}"
+
+
+def main() -> None:
+    args = parse_args()
+    timezone = pytz.timezone("America/New_York")
+    now_ny = datetime.now(timezone)
+
+    if args.skip_if_monday_holiday and was_monday_holiday(now_ny):
+        monday = (now_ny - timedelta(days=now_ny.weekday())).date()
+        print(f"Skipping run because Monday {monday} is a US federal holiday.")
+        return
+
+    ensure_dir(args.workdir)
+    tickers = [t.strip() for t in args.tickers.split(",") if t.strip()]
+    if not tickers:
+        raise SystemExit("No tickers provided.")
+
+    end_date = args.end or now_ny.date().strftime("%Y-%m-%d")
+
+    csv_paths: list[str] = []
+    for ticker in tickers:
+        out_path = os.path.join(args.workdir, f"{ticker.upper()}_{args.start}_{end_date}.csv")
+        csv_paths.append(
+            colab_download_price_csv(
+                ticker,
+                start=args.start,
+                end=end_date,
+                interval=args.interval,
+                out_path=out_path,
+            )
+        )
+
+    training_df = build_training_dataframe(csv_paths)
+    training_path = os.path.join(args.workdir, "autopilot_ts_train.csv")
+    training_df.to_csv(training_path, index=False)
+
+    s3_train_key = f"{args.s3-prefix}/data/train/autopilot_ts_train.csv"
+    s3_output_prefix = f"s3://{args.s3_bucket}/{args.s3_prefix}/output"
+    upload_to_s3(training_path, args.s3_bucket, s3_train_key, args.region)
+
+    job_timestamp = datetime.utcnow().strftime("%Y%m%d-%H%M%S")
+    automl_job_name = f"{args.job_name_prefix}-{job_timestamp}"
+
+    automl_job_input_data_config = [
+        {
+            "ChannelType": "training",
+            "ContentType": "text/csv;header=present",
+            "CompressionType": "None",
+            "DataSource": {
+                "S3DataSource": {
+                    "S3DataType": "S3Prefix",
+                    "S3Uri": f"s3://{args.s3_bucket}/{args.s3_prefix}/data/train/",
+                }
+            },
+        }
+    ]
+
+    forecast_horizon = args.forecast_horizon
+    if args.frequency.upper().endswith("H"):
+        forecast_horizon *= 24
+
+    automl_problem_type_config = {
+        "TimeSeriesForecastingJobConfig": {
+            "CompletionCriteria": {"MaxAutoMLJobRuntimeInSeconds": args.max_runtime_seconds},
+            "ForecastFrequency": args.frequency.upper(),
+            "ForecastHorizon": forecast_horizon,
+            "ForecastQuantiles": ["p10", "p50", "p90"],
+            "TimeSeriesConfig": {
+                "TargetAttributeName": "target",
+                "TimestampAttributeName": "ts",
+                "ItemIdentifierAttributeName": "item_id",
+            },
+        }
+    }
+
+    sm = boto3.client("sagemaker", region_name=args.region)
+    sm.create_auto_ml_job_v2(
+        AutoMLJobName=automl_job_name,
+        AutoMLJobInputDataConfig=automl_job_input_data_config,
+        OutputDataConfig={"S3OutputPath": s3_output_prefix},
+        AutoMLProblemTypeConfig=automl_problem_type_config,
+        AutoMLJobObjective={"MetricName": "AverageWeightedQuantileLoss"},
+        RoleArn=args.role_arn,
+    )
+
+    print(f"Started Autopilot job: {automl_job_name}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Motivation
- Provide an automated end-to-end Autopilot time-series workflow that uses existing historical stock fetch logic and can be run on a schedule.
- Ensure runs are skipped when the preceding Monday is a US federal holiday to avoid triggering training for markets that were closed.
- Launch Autopilot time-series jobs with prepared CSV input on S3 so forecasts can be produced and inspected in SageMaker.

### Description
- Added `scripts/run_autopilot_timeseries.py`, a CLI that fetches historical prices via the existing `fetch_data.colab_download_price_csv`, builds a combined training CSV, uploads it to S3, and calls `boto3.create_auto_ml_job_v2` to start a SageMaker Autopilot time-series job. 
- The script accepts arguments for tickers, date range, S3 bucket/prefix, role ARN, region, forecast horizon and frequency, and includes a `--skip-if-monday-holiday` option that uses `USFederalHolidayCalendar` to avoid runs when Monday is a federal holiday; the `--end` date now defaults to today when not provided. 
- Added a GitHub Actions workflow ` .github/workflows/autopilot_timeseries.yml` that runs on a schedule (cron `0 21 * * 2` — Tuesdays 21:00 UTC / 4 PM EST) and via `workflow_dispatch`, installs dependencies, and invokes the script with repository secrets for tickers, IAM role, S3 bucket, and AWS credentials. 
- The workflow calls the script with `--skip-if-monday-holiday` enabled and uploads the training CSV to the configured S3 prefix `autopilot-stock-forecast` prior to starting the Autopilot job. 

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69893d291f3c8320995907eddd05f322)